### PR TITLE
feat: helpers for Type Inference from API Endpoints

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2024-PRESENT Johann Schopplich
+Copyright (c) 2025-PRESENT Wind (@productdevbook)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/reference/openapi-type-helpers.md
+++ b/docs/reference/openapi-type-helpers.md
@@ -2,7 +2,7 @@
 
 When building clients with the [`OpenAPIBuilder` extension](/extensions/openapi), you may want to access the request and response types for each operation in the OpenAPI schema. APIful provides a set of shorthand types to help you with this.
 
-## Example
+## Basic Operation Helpers
 
 Given the API service name `petStore`, APIful generates the following types:
 
@@ -37,3 +37,55 @@ interface _Pet {
   status?: 'available' | 'pending' | 'sold'
 }
 ```
+
+## Path-based Type Helpers
+
+In addition to operation-based helpers, APIful also provides more direct path-based type helpers. These allow you to extract types directly from path and HTTP method combinations:
+
+- `PathParamsFrom<API>` - Extract path parameters for a specific path and method
+- `RequestBodyFrom<API>` - Extract request body type for a specific path and method
+- `QueryParamsFrom<API>` - Extract query parameters for a specific path and method
+- `ResponseFrom<API>` - Extract response body type for a specific path and method with optional status code
+
+### Examples
+
+Using the same `petStore` API, you can access types directly from paths:
+
+```ts
+import type {
+  PathParamsFromPetStore,
+  RequestBodyFromPetStore,
+  QueryParamsFromPetStore,
+  ResponseFromPetStore
+} from 'apiful/schema'
+
+// Path parameters for GET /pet/{petId}
+type PetIdParam = PathParamsFromPetStore<'/pet/{petId}', 'get'>
+//   ^? { petId: number }
+
+// Request body for POST /pet
+type CreatePetBody = RequestBodyFromPetStore<'/pet', 'post'>
+//   ^? { id?: number; name: string; /* ... */ }
+
+// Query parameters for GET /pet/findByStatus
+type StatusQueryParam = QueryParamsFromPetStore<'/pet/findByStatus', 'get'>
+//   ^? { status?: "available" | "pending" | "sold" }
+
+// Response type for GET /pet/{petId}
+type PetResponse = ResponseFromPetStore<'/pet/{petId}', 'get'>
+//   ^? { id?: number; name: string; /* ... */ }
+
+// Response type for a specific status code (e.g., 201 Created)
+type CreatedPetResponse = ResponseFromPetStore<'/pet', 'post', '201'>
+```
+
+### Benefits of Path-based Helpers
+
+The path-based helpers offer several advantages:
+
+1. **Direct access by URL path** - Use the actual API path as you would write it in your code
+2. **HTTP method specificity** - Extract types for specific HTTP methods on the same path
+3. **Status code support** - Extract response types for specific status codes
+4. **IDE integration** - Better completion support in IDEs since paths are directly tied to your OpenAPI schema
+
+These path-based helpers work particularly well when you want to type parameters or responses for specific API endpoints that you're working with in your code.

--- a/docs/reference/openapi-type-helpers.md
+++ b/docs/reference/openapi-type-helpers.md
@@ -54,8 +54,8 @@ Using the same `petStore` API, you can access types directly from paths:
 ```ts
 import type {
   PathParamsFromPetStore,
-  RequestBodyFromPetStore,
   QueryParamsFromPetStore,
+  RequestBodyFromPetStore,
   ResponseFromPetStore
 } from 'apiful/schema'
 

--- a/src/openapi/generate.ts
+++ b/src/openapi/generate.ts
@@ -129,8 +129,6 @@ ${CODE_HEADER_DIRECTIVES}
 declare module 'apiful/schema' {
 ${imports}
 
-  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never
-
   type NonNeverKeys<T> = {
     [K in keyof T]: [T[K]] extends [never]
       ? never
@@ -138,8 +136,8 @@ ${imports}
         ? [never] extends [Exclude<T[K], undefined>] ? never : K
         : K;
   }[keyof T];
-
   type NonNeverKeysWithoutParams<T> = Exclude<NonNeverKeys<T>, 'parameters'>
+  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never
 
   interface OpenAPISchemaRepository {
 ${repositoryEntries}

--- a/src/openapi/generate.ts
+++ b/src/openapi/generate.ts
@@ -4,6 +4,8 @@ import { defu } from 'defu'
 import { pascalCase } from 'scule'
 import { CODE_HEADER_DIRECTIVES } from '../constants'
 
+export type ParseInt<S extends string> = S extends `${infer N extends number}` ? N : never
+
 export async function generateDTS(
   services: Record<string, ServiceOptions>,
   openAPITSOptions?: OpenAPITSOptions,
@@ -19,40 +21,136 @@ export async function generateDTS(
 
   const resolvedSchemas = Object.fromEntries(resolvedSchemaEntries)
 
-  return `
-${CODE_HEADER_DIRECTIVES}
-declare module 'apiful/schema' {
-${Object.keys(resolvedSchemas)
-  .map(i => `  import { paths as ${pascalCase(i)}Paths, operations as ${pascalCase(i)}Operations } from 'apiful/__${i}__'`)
-  .join('\n')}
+  const serviceIds = Object.keys(resolvedSchemas)
 
-  interface OpenAPISchemaRepository {
-${Object.keys(resolvedSchemas)
-  .map(i => `${i}: ${pascalCase(i)}Paths`.replace(/^/gm, '    '))
-  .join('\n')}
-  }
+  // Build import statements
+  const imports = serviceIds
+    .map(id => `  import { paths as ${pascalCase(id)}Paths, operations as ${pascalCase(id)}Operations } from 'apiful/__${id}__'`)
+    .join('\n')
 
-${Object.keys(resolvedSchemas)
-  .map(i => `  export type ${pascalCase(i)}Response<
-    T extends keyof ${pascalCase(i)}Operations,
-    R extends keyof ${pascalCase(i)}Operations[T]['responses'] = 200 extends keyof ${pascalCase(i)}Operations[T]['responses'] ? 200 : never
-  > = ${pascalCase(i)}Operations[T]['responses'][R] extends { content: { 'application/json': infer U } } ? U : never
-  export type ${pascalCase(i)}RequestBody<
-    T extends keyof ${pascalCase(i)}Operations
-  > = ${pascalCase(i)}Operations[T]['requestBody'] extends { content: { 'application/json': infer U } } ? U : never
-  export type ${pascalCase(i)}RequestQuery<
-    T extends keyof ${pascalCase(i)}Operations
-  > = ${pascalCase(i)}Operations[T]['parameters'] extends { query?: infer U } ? U : never
-`)
-  .join('\n')
-  .trimEnd()}
-}
+  // Build repository interface entries
+  const repositoryEntries = serviceIds
+    .map(id => `    ${id}: ${pascalCase(id)}Paths`)
+    .join('\n')
 
-${Object.entries(resolvedSchemas)
-  .map(([id, types]) => `declare module 'apiful/__${id}__' {
+  // Build type exports
+  const typeExports = serviceIds
+    .map((id) => {
+      return [
+        `  export type ${pascalCase(id)}Response<`,
+        `    T extends keyof ${pascalCase(id)}Operations,`,
+        `    R extends keyof ${pascalCase(id)}Operations[T]['responses'] = 200 extends keyof ${pascalCase(id)}Operations[T]['responses'] ? 200 : never`,
+        `  > = ${pascalCase(id)}Operations[T]['responses'][R] extends { content: { 'application/json': infer U } } ? U : never`,
+        `  export type ${pascalCase(id)}RequestBody<`,
+        `    T extends keyof ${pascalCase(id)}Operations`,
+        `  > = ${pascalCase(id)}Operations[T]['requestBody'] extends { content: { 'application/json': infer U } } ? U : never`,
+        `  export type ${pascalCase(id)}RequestQuery<`,
+        `    T extends keyof ${pascalCase(id)}Operations`,
+        `  > = ${pascalCase(id)}Operations[T]['parameters'] extends { query?: infer U } ? U : never`,
+
+        `  // Helper type to get the operation from a path entry`,
+        `  export type GetOperation<T, M extends string> = `,
+        `    M extends 'get' ? T extends { get: infer Op } ? Op : never :`,
+        `    M extends 'post' ? T extends { post: infer Op } ? Op : never :`,
+        `    M extends 'put' ? T extends { put: infer Op } ? Op : never :`,
+        `    M extends 'delete' ? T extends { delete: infer Op } ? Op : never :`,
+        `    M extends 'patch' ? T extends { patch: infer Op } ? Op : never :`,
+        `    never;`,
+
+        `  // Direct type that allows accessing path parameters by specifying the HTTP method`,
+        `  export type PathParamsFrom${pascalCase(id)}<`,
+        `  P extends keyof ${pascalCase(id)}Paths,`,
+        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>`,
+        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
+        `  ? Op extends { parameters?: any }`,
+        `    ? NonNullable<Op['parameters']>['path'] extends infer Params`,
+        `      ? Params extends object`,
+        `        ? Params`,
+        `        : Record<string, never>`,
+        `      : Record<string, never>`,
+        `    : Record<string, never>`,
+        `  : Record<string, never>;`,
+
+        `  // Direct type that allows accessing request body by specifying the HTTP method`,
+        `  export type RequestBodyFrom${pascalCase(id)}<`,
+        `  P extends keyof ${pascalCase(id)}Paths,`,
+        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>`,
+        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
+        `  ? Op extends { requestBody?: any }`,
+        `    ? NonNullable<Op['requestBody']>['content']['application/json'] extends infer Body`,
+        `      ? Body extends object`,
+        `        ? Body`,
+        `        : Record<string, never>`,
+        `      : Record<string, never>`,
+        `    : Record<string, never>`,
+        `  : Record<string, never>;`,
+
+        `  // Direct type that allows accessing query parameters by specifying the HTTP method`,
+        `  export type QueryParamsFrom${pascalCase(id)}<`,
+        `  P extends keyof ${pascalCase(id)}Paths,`,
+        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>`,
+        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
+        `  ? Op extends { parameters?: any }`,
+        `    ? NonNullable<Op['parameters']>['query'] extends infer Params`,
+        `      ? Params extends object`,
+        `        ? Params`,
+        `        : Record<string, never>`,
+        `      : Record<string, never>`,
+        `    : Record<string, never>`,
+        `  : Record<string, never>;`,
+
+        `  // Direct type that allows accessing response body by specifying the HTTP method`,
+        `  export type ResponseFrom${pascalCase(id)}<`,
+        `  P extends keyof ${pascalCase(id)}Paths,`,
+        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>,`,
+        `  C extends \`\${keyof NonNullable<GetOperation<${pascalCase(id)}Paths[P], M>>['responses']}\` = '200'`,
+        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
+        `  ? Op extends { responses?: any }`,
+        `    ? ParseInt<C> extends keyof Op['responses']`,
+        `      ? Op['responses'][ParseInt<C>] extends { content: { 'application/json': infer Body } }`,
+        `        ? Body`,
+        `        : Record<string, never>`,
+        `      : Record<string, never>`,
+        `    : Record<string, never>`,
+        `  : Record<string, never>;`,
+      ].join('\n')
+    })
+    .join('\n\n')
+
+  // Build module declarations
+  const moduleDeclarations = Object.entries(resolvedSchemas)
+    .map(([id, types]) => `declare module 'apiful/__${id}__' {
 ${normalizeIndentation(types).trimEnd()}
 }`)
-  .join('\n\n')}
+    .join('\n\n')
+
+
+  return `
+${CODE_HEADER_DIRECTIVES}
+
+declare module 'apiful/schema' {
+${imports}
+
+  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never;
+
+  type NonNeverKeys<T> = {
+    [K in keyof T]: [T[K]] extends [never] ? never : 
+                    [undefined] extends [T[K]] ? (
+                      [never] extends [Exclude<T[K], undefined>] ? never : K
+                    ) : K
+  }[keyof T];
+
+  type NonNeverKeysWithout<T> = Exclude<NonNeverKeys<T>, 'parameters'>;
+
+
+  interface OpenAPISchemaRepository {
+${repositoryEntries}
+  }
+
+${typeExports}
+}
+
+${moduleDeclarations}
 `.trimStart()
 }
 

--- a/src/openapi/generate.ts
+++ b/src/openapi/generate.ts
@@ -20,7 +20,6 @@ export async function generateDTS(
   )
 
   const resolvedSchemas = Object.fromEntries(resolvedSchemaEntries)
-
   const serviceIds = Object.keys(resolvedSchemas)
 
   // Build import statements
@@ -36,84 +35,84 @@ export async function generateDTS(
   // Build type exports
   const typeExports = serviceIds
     .map((id) => {
-      return [
-        `  export type ${pascalCase(id)}Response<`,
-        `    T extends keyof ${pascalCase(id)}Operations,`,
-        `    R extends keyof ${pascalCase(id)}Operations[T]['responses'] = 200 extends keyof ${pascalCase(id)}Operations[T]['responses'] ? 200 : never`,
-        `  > = ${pascalCase(id)}Operations[T]['responses'][R] extends { content: { 'application/json': infer U } } ? U : never`,
-        `  export type ${pascalCase(id)}RequestBody<`,
-        `    T extends keyof ${pascalCase(id)}Operations`,
-        `  > = ${pascalCase(id)}Operations[T]['requestBody'] extends { content: { 'application/json': infer U } } ? U : never`,
-        `  export type ${pascalCase(id)}RequestQuery<`,
-        `    T extends keyof ${pascalCase(id)}Operations`,
-        `  > = ${pascalCase(id)}Operations[T]['parameters'] extends { query?: infer U } ? U : never`,
+      return [`
+export type ${pascalCase(id)}Response<
+  T extends keyof ${pascalCase(id)}Operations,
+  R extends keyof ${pascalCase(id)}Operations[T]['responses'] = 200 extends keyof ${pascalCase(id)}Operations[T]['responses'] ? 200 : never
+> = ${pascalCase(id)}Operations[T]['responses'][R] extends { content: { 'application/json': infer U } } ? U : never
+export type ${pascalCase(id)}RequestBody<
+  T extends keyof ${pascalCase(id)}Operations
+> = ${pascalCase(id)}Operations[T]['requestBody'] extends { content: { 'application/json': infer U } } ? U : never
+export type ${pascalCase(id)}RequestQuery<
+  T extends keyof ${pascalCase(id)}Operations
+> = ${pascalCase(id)}Operations[T]['parameters'] extends { query?: infer U } ? U : never
 
-        `  // Helper type to get the operation from a path entry`,
-        `  export type GetOperation<T, M extends string> = `,
-        `    M extends 'get' ? T extends { get: infer Op } ? Op : never :`,
-        `    M extends 'post' ? T extends { post: infer Op } ? Op : never :`,
-        `    M extends 'put' ? T extends { put: infer Op } ? Op : never :`,
-        `    M extends 'delete' ? T extends { delete: infer Op } ? Op : never :`,
-        `    M extends 'patch' ? T extends { patch: infer Op } ? Op : never :`,
-        `    never;`,
+// Helper type to get the operation from a path entry
+export type GetOperation<T, M extends string> =
+  M extends 'get' ? T extends { get: infer Op } ? Op : never :
+  M extends 'post' ? T extends { post: infer Op } ? Op : never :
+  M extends 'put' ? T extends { put: infer Op } ? Op : never :
+  M extends 'delete' ? T extends { delete: infer Op } ? Op : never :
+  M extends 'patch' ? T extends { patch: infer Op } ? Op : never :
+  never
 
-        `  // Direct type that allows accessing path parameters by specifying the HTTP method`,
-        `  export type PathParamsFrom${pascalCase(id)}<`,
-        `  P extends keyof ${pascalCase(id)}Paths,`,
-        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>`,
-        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
-        `  ? Op extends { parameters?: any }`,
-        `    ? NonNullable<Op['parameters']>['path'] extends infer Params`,
-        `      ? Params extends object`,
-        `        ? Params`,
-        `        : Record<string, never>`,
-        `      : Record<string, never>`,
-        `    : Record<string, never>`,
-        `  : Record<string, never>;`,
+// Direct type that allows accessing path parameters by specifying the HTTP method
+export type PathParamsFrom${pascalCase(id)}<
+  P extends keyof ${pascalCase(id)}Paths,
+  M extends NonNeverKeysWithoutParams<${pascalCase(id)}Paths[P]>
+> = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op
+  ? Op extends { parameters?: any }
+    ? NonNullable<Op['parameters']>['path'] extends infer Params
+      ? Params extends object
+        ? Params
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>
 
-        `  // Direct type that allows accessing request body by specifying the HTTP method`,
-        `  export type RequestBodyFrom${pascalCase(id)}<`,
-        `  P extends keyof ${pascalCase(id)}Paths,`,
-        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>`,
-        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
-        `  ? Op extends { requestBody?: any }`,
-        `    ? NonNullable<Op['requestBody']>['content']['application/json'] extends infer Body`,
-        `      ? Body extends object`,
-        `        ? Body`,
-        `        : Record<string, never>`,
-        `      : Record<string, never>`,
-        `    : Record<string, never>`,
-        `  : Record<string, never>;`,
+// Direct type that allows accessing request body by specifying the HTTP method
+export type RequestBodyFrom${pascalCase(id)}<
+  P extends keyof ${pascalCase(id)}Paths,
+  M extends NonNeverKeysWithoutParams<${pascalCase(id)}Paths[P]>
+> = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op
+  ? Op extends { requestBody?: any }
+    ? NonNullable<Op['requestBody']>['content']['application/json'] extends infer Body
+      ? Body extends object
+        ? Body
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>
 
-        `  // Direct type that allows accessing query parameters by specifying the HTTP method`,
-        `  export type QueryParamsFrom${pascalCase(id)}<`,
-        `  P extends keyof ${pascalCase(id)}Paths,`,
-        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>`,
-        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
-        `  ? Op extends { parameters?: any }`,
-        `    ? NonNullable<Op['parameters']>['query'] extends infer Params`,
-        `      ? Params extends object`,
-        `        ? Params`,
-        `        : Record<string, never>`,
-        `      : Record<string, never>`,
-        `    : Record<string, never>`,
-        `  : Record<string, never>;`,
+// Direct type that allows accessing query parameters by specifying the HTTP method
+export type QueryParamsFrom${pascalCase(id)}<
+  P extends keyof ${pascalCase(id)}Paths,
+  M extends NonNeverKeysWithoutParams<${pascalCase(id)}Paths[P]>
+> = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op
+  ? Op extends { parameters?: any }
+    ? NonNullable<Op['parameters']>['query'] extends infer Params
+      ? Params extends object
+        ? Params
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>
 
-        `  // Direct type that allows accessing response body by specifying the HTTP method`,
-        `  export type ResponseFrom${pascalCase(id)}<`,
-        `  P extends keyof ${pascalCase(id)}Paths,`,
-        `  M extends NonNeverKeysWithout<${pascalCase(id)}Paths[P]>,`,
-        `  C extends \`\${keyof NonNullable<GetOperation<${pascalCase(id)}Paths[P], M>>['responses']}\` = '200'`,
-        `  > = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op`,
-        `  ? Op extends { responses?: any }`,
-        `    ? ParseInt<C> extends keyof Op['responses']`,
-        `      ? Op['responses'][ParseInt<C>] extends { content: { 'application/json': infer Body } }`,
-        `        ? Body`,
-        `        : Record<string, never>`,
-        `      : Record<string, never>`,
-        `    : Record<string, never>`,
-        `  : Record<string, never>;`,
-      ].join('\n')
+// Direct type that allows accessing response body by specifying the HTTP method
+export type ResponseFrom${pascalCase(id)}<
+  P extends keyof ${pascalCase(id)}Paths,
+  M extends NonNeverKeysWithoutParams<${pascalCase(id)}Paths[P]>,
+  C extends \`\${keyof NonNullable<GetOperation<${pascalCase(id)}Paths[P], M>>['responses']}\` = '200'
+> = GetOperation<${pascalCase(id)}Paths[P], M> extends infer Op
+  ? Op extends { responses?: any }
+    ? ParseInt<C> extends keyof Op['responses']
+      ? Op['responses'][ParseInt<C>] extends { content: { 'application/json': infer Body } }
+        ? Body
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>
+`.trim()].join('\n')
     })
     .join('\n\n')
 
@@ -130,23 +129,23 @@ ${CODE_HEADER_DIRECTIVES}
 declare module 'apiful/schema' {
 ${imports}
 
-  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never;
+  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never
 
   type NonNeverKeys<T> = {
-    [K in keyof T]: [T[K]] extends [never] ? never : 
-                    [undefined] extends [T[K]] ? (
-                      [never] extends [Exclude<T[K], undefined>] ? never : K
-                    ) : K
+    [K in keyof T]: [T[K]] extends [never]
+      ? never
+      : [undefined] extends [T[K]]
+        ? [never] extends [Exclude<T[K], undefined>] ? never : K
+        : K;
   }[keyof T];
 
-  type NonNeverKeysWithout<T> = Exclude<NonNeverKeys<T>, 'parameters'>;
-
+  type NonNeverKeysWithoutParams<T> = Exclude<NonNeverKeys<T>, 'parameters'>
 
   interface OpenAPISchemaRepository {
 ${repositoryEntries}
   }
 
-${typeExports}
+${applyLineIndent(typeExports)}
 }
 
 ${moduleDeclarations}
@@ -207,6 +206,14 @@ function isValidUrl(url: string) {
   catch {
     return false
   }
+}
+
+// Add indentation of two spaces to each line
+function applyLineIndent(code: string) {
+  return code
+    .split('\n')
+    .map(line => line.replace(/^/gm, '  '))
+    .join('\n')
 }
 
 function normalizeIndentation(code: string) {

--- a/src/openapi/generate.ts
+++ b/src/openapi/generate.ts
@@ -124,7 +124,6 @@ ${normalizeIndentation(types).trimEnd()}
 }`)
     .join('\n\n')
 
-
   return `
 ${CODE_HEADER_DIRECTIVES}
 

--- a/test/__snapshots__/openapi.test.ts.snap
+++ b/test/__snapshots__/openapi.test.ts.snap
@@ -8,8 +8,6 @@ exports[`OpenAPI to TypeScript > generates OpenAPI types 1`] = `
 declare module 'apiful/schema' {
   import { paths as TestEchoPaths, operations as TestEchoOperations } from 'apiful/__testEcho__'
 
-  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never
-
   type NonNeverKeys<T> = {
     [K in keyof T]: [T[K]] extends [never]
       ? never
@@ -17,8 +15,8 @@ declare module 'apiful/schema' {
         ? [never] extends [Exclude<T[K], undefined>] ? never : K
         : K;
   }[keyof T];
-
   type NonNeverKeysWithoutParams<T> = Exclude<NonNeverKeys<T>, 'parameters'>
+  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never
 
   interface OpenAPISchemaRepository {
     testEcho: TestEchoPaths

--- a/test/__snapshots__/openapi.test.ts.snap
+++ b/test/__snapshots__/openapi.test.ts.snap
@@ -8,17 +8,17 @@ exports[`OpenAPI to TypeScript > generates OpenAPI types 1`] = `
 declare module 'apiful/schema' {
   import { paths as TestEchoPaths, operations as TestEchoOperations } from 'apiful/__testEcho__'
 
-  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never;
+  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never
 
   type NonNeverKeys<T> = {
-    [K in keyof T]: [T[K]] extends [never] ? never : 
-                    [undefined] extends [T[K]] ? (
-                      [never] extends [Exclude<T[K], undefined>] ? never : K
-                    ) : K
+    [K in keyof T]: [T[K]] extends [never]
+      ? never
+      : [undefined] extends [T[K]]
+        ? [never] extends [Exclude<T[K], undefined>] ? never : K
+        : K;
   }[keyof T];
 
-  type NonNeverKeysWithout<T> = Exclude<NonNeverKeys<T>, 'parameters'>;
-
+  type NonNeverKeysWithoutParams<T> = Exclude<NonNeverKeys<T>, 'parameters'>
 
   interface OpenAPISchemaRepository {
     testEcho: TestEchoPaths
@@ -34,67 +34,72 @@ declare module 'apiful/schema' {
   export type TestEchoRequestQuery<
     T extends keyof TestEchoOperations
   > = TestEchoOperations[T]['parameters'] extends { query?: infer U } ? U : never
+  
   // Helper type to get the operation from a path entry
-  export type GetOperation<T, M extends string> = 
+  export type GetOperation<T, M extends string> =
     M extends 'get' ? T extends { get: infer Op } ? Op : never :
     M extends 'post' ? T extends { post: infer Op } ? Op : never :
     M extends 'put' ? T extends { put: infer Op } ? Op : never :
     M extends 'delete' ? T extends { delete: infer Op } ? Op : never :
     M extends 'patch' ? T extends { patch: infer Op } ? Op : never :
-    never;
+    never
+  
   // Direct type that allows accessing path parameters by specifying the HTTP method
   export type PathParamsFromTestEcho<
-  P extends keyof TestEchoPaths,
-  M extends NonNeverKeysWithout<TestEchoPaths[P]>
+    P extends keyof TestEchoPaths,
+    M extends NonNeverKeysWithoutParams<TestEchoPaths[P]>
   > = GetOperation<TestEchoPaths[P], M> extends infer Op
-  ? Op extends { parameters?: any }
-    ? NonNullable<Op['parameters']>['path'] extends infer Params
-      ? Params extends object
-        ? Params
+    ? Op extends { parameters?: any }
+      ? NonNullable<Op['parameters']>['path'] extends infer Params
+        ? Params extends object
+          ? Params
+          : Record<string, never>
         : Record<string, never>
       : Record<string, never>
     : Record<string, never>
-  : Record<string, never>;
+  
   // Direct type that allows accessing request body by specifying the HTTP method
   export type RequestBodyFromTestEcho<
-  P extends keyof TestEchoPaths,
-  M extends NonNeverKeysWithout<TestEchoPaths[P]>
+    P extends keyof TestEchoPaths,
+    M extends NonNeverKeysWithoutParams<TestEchoPaths[P]>
   > = GetOperation<TestEchoPaths[P], M> extends infer Op
-  ? Op extends { requestBody?: any }
-    ? NonNullable<Op['requestBody']>['content']['application/json'] extends infer Body
-      ? Body extends object
-        ? Body
+    ? Op extends { requestBody?: any }
+      ? NonNullable<Op['requestBody']>['content']['application/json'] extends infer Body
+        ? Body extends object
+          ? Body
+          : Record<string, never>
         : Record<string, never>
       : Record<string, never>
     : Record<string, never>
-  : Record<string, never>;
+  
   // Direct type that allows accessing query parameters by specifying the HTTP method
   export type QueryParamsFromTestEcho<
-  P extends keyof TestEchoPaths,
-  M extends NonNeverKeysWithout<TestEchoPaths[P]>
+    P extends keyof TestEchoPaths,
+    M extends NonNeverKeysWithoutParams<TestEchoPaths[P]>
   > = GetOperation<TestEchoPaths[P], M> extends infer Op
-  ? Op extends { parameters?: any }
-    ? NonNullable<Op['parameters']>['query'] extends infer Params
-      ? Params extends object
-        ? Params
+    ? Op extends { parameters?: any }
+      ? NonNullable<Op['parameters']>['query'] extends infer Params
+        ? Params extends object
+          ? Params
+          : Record<string, never>
         : Record<string, never>
       : Record<string, never>
     : Record<string, never>
-  : Record<string, never>;
+  
   // Direct type that allows accessing response body by specifying the HTTP method
   export type ResponseFromTestEcho<
-  P extends keyof TestEchoPaths,
-  M extends NonNeverKeysWithout<TestEchoPaths[P]>,
-  C extends \`\${keyof NonNullable<GetOperation<TestEchoPaths[P], M>>['responses']}\` = '200'
+    P extends keyof TestEchoPaths,
+    M extends NonNeverKeysWithoutParams<TestEchoPaths[P]>,
+    C extends \`\${keyof NonNullable<GetOperation<TestEchoPaths[P], M>>['responses']}\` = '200'
   > = GetOperation<TestEchoPaths[P], M> extends infer Op
-  ? Op extends { responses?: any }
-    ? ParseInt<C> extends keyof Op['responses']
-      ? Op['responses'][ParseInt<C>] extends { content: { 'application/json': infer Body } }
-        ? Body
+    ? Op extends { responses?: any }
+      ? ParseInt<C> extends keyof Op['responses']
+        ? Op['responses'][ParseInt<C>] extends { content: { 'application/json': infer Body } }
+          ? Body
+          : Record<string, never>
         : Record<string, never>
       : Record<string, never>
     : Record<string, never>
-  : Record<string, never>;
 }
 
 declare module 'apiful/__testEcho__' {

--- a/test/__snapshots__/openapi.test.ts.snap
+++ b/test/__snapshots__/openapi.test.ts.snap
@@ -4,8 +4,21 @@ exports[`OpenAPI to TypeScript > generates OpenAPI types 1`] = `
 "/* eslint-disable */
 /* prettier-ignore */
 
+
 declare module 'apiful/schema' {
   import { paths as TestEchoPaths, operations as TestEchoOperations } from 'apiful/__testEcho__'
+
+  type ParseInt<S extends string> = S extends \`\${infer N extends number}\` ? N : never;
+
+  type NonNeverKeys<T> = {
+    [K in keyof T]: [T[K]] extends [never] ? never : 
+                    [undefined] extends [T[K]] ? (
+                      [never] extends [Exclude<T[K], undefined>] ? never : K
+                    ) : K
+  }[keyof T];
+
+  type NonNeverKeysWithout<T> = Exclude<NonNeverKeys<T>, 'parameters'>;
+
 
   interface OpenAPISchemaRepository {
     testEcho: TestEchoPaths
@@ -21,6 +34,67 @@ declare module 'apiful/schema' {
   export type TestEchoRequestQuery<
     T extends keyof TestEchoOperations
   > = TestEchoOperations[T]['parameters'] extends { query?: infer U } ? U : never
+  // Helper type to get the operation from a path entry
+  export type GetOperation<T, M extends string> = 
+    M extends 'get' ? T extends { get: infer Op } ? Op : never :
+    M extends 'post' ? T extends { post: infer Op } ? Op : never :
+    M extends 'put' ? T extends { put: infer Op } ? Op : never :
+    M extends 'delete' ? T extends { delete: infer Op } ? Op : never :
+    M extends 'patch' ? T extends { patch: infer Op } ? Op : never :
+    never;
+  // Direct type that allows accessing path parameters by specifying the HTTP method
+  export type PathParamsFromTestEcho<
+  P extends keyof TestEchoPaths,
+  M extends NonNeverKeysWithout<TestEchoPaths[P]>
+  > = GetOperation<TestEchoPaths[P], M> extends infer Op
+  ? Op extends { parameters?: any }
+    ? NonNullable<Op['parameters']>['path'] extends infer Params
+      ? Params extends object
+        ? Params
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>;
+  // Direct type that allows accessing request body by specifying the HTTP method
+  export type RequestBodyFromTestEcho<
+  P extends keyof TestEchoPaths,
+  M extends NonNeverKeysWithout<TestEchoPaths[P]>
+  > = GetOperation<TestEchoPaths[P], M> extends infer Op
+  ? Op extends { requestBody?: any }
+    ? NonNullable<Op['requestBody']>['content']['application/json'] extends infer Body
+      ? Body extends object
+        ? Body
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>;
+  // Direct type that allows accessing query parameters by specifying the HTTP method
+  export type QueryParamsFromTestEcho<
+  P extends keyof TestEchoPaths,
+  M extends NonNeverKeysWithout<TestEchoPaths[P]>
+  > = GetOperation<TestEchoPaths[P], M> extends infer Op
+  ? Op extends { parameters?: any }
+    ? NonNullable<Op['parameters']>['query'] extends infer Params
+      ? Params extends object
+        ? Params
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>;
+  // Direct type that allows accessing response body by specifying the HTTP method
+  export type ResponseFromTestEcho<
+  P extends keyof TestEchoPaths,
+  M extends NonNeverKeysWithout<TestEchoPaths[P]>,
+  C extends \`\${keyof NonNullable<GetOperation<TestEchoPaths[P], M>>['responses']}\` = '200'
+  > = GetOperation<TestEchoPaths[P], M> extends infer Op
+  ? Op extends { responses?: any }
+    ? ParseInt<C> extends keyof Op['responses']
+      ? Op['responses'][ParseInt<C>] extends { content: { 'application/json': infer Body } }
+        ? Body
+        : Record<string, never>
+      : Record<string, never>
+    : Record<string, never>
+  : Record<string, never>;
 }
 
 declare module 'apiful/__testEcho__' {


### PR DESCRIPTION
This update introduces new TypeScript helper types to enhance type inference for various API-related structures. The following types were added to facilitate working with endpoint paths, request bodies, query parameters, and responses:

PathParamsFromAPI: Inference for path parameters based on the API path and method.

RequestBodyFromAPI: Inference for request bodies for PUT, POST, and other methods.

QueryParamsFromAPI: Inference for query parameters based on the API path and method.

ResponseFromAPI: Inference for expected responses based on the API path, method, and status code.

```ts
  const test: PathParamsFromPetStore<'/pet/{petId}', 'get'> = {
    petId: 1,
  }

  const test2: RequestBodyFromPetStore<'/pet', 'put'> = {
    name: "Fluffy",
    age: 3,
  }

  const test3: QueryParamsFromPetStore<'/pet/findByStatus', 'get'> = {
    status: 'available'
  }

  const test4: ResponseFromPetStore<'/pet/findByStatus', 'get', '200'> = [
    {
      id: 1,
      name: "Fluffy",
      status: "available"
    }
  ]
 ```