### PR TITLE
refactor: unbundle build

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     }
   },
   "dependencies": {
-    "@types/json-schema": "^7.0.15",
     "c12": "^3.1.0",
     "citty": "^0.1.6",
     "consola": "^3.4.2",
@@ -110,6 +109,7 @@
     "@antfu/eslint-config": "^4.16.2",
     "@iconify-json/carbon": "^1.2.10",
     "@iconify-json/devicon-plain": "^1.2.30",
+    "@types/json-schema": "^7.0.15",
     "@types/node": "^22.16.3",
     "bumpp": "^10.2.0",
     "eslint": "^9.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
 
   .:
     dependencies:
-      '@types/json-schema':
-        specifier: ^7.0.15
-        version: 7.0.15
       c12:
         specifier: ^3.1.0
         version: 3.1.0
@@ -46,6 +43,9 @@ importers:
       '@iconify-json/devicon-plain':
         specifier: ^1.2.30
         version: 1.2.30
+      '@types/json-schema':
+        specifier: ^7.0.15
+        version: 7.0.15
       '@types/node':
         specifier: ^22.16.3
         version: 22.16.3

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -15,6 +15,7 @@ const config: UserConfig | UserConfigFn = defineConfig({
     'openapi-typescript',
   ],
   dts: true,
+  unbundle: true,
 })
 
 export default config

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,6 +13,7 @@ const config: UserConfig | UserConfigFn = defineConfig({
     'json-schema',
     'json-schema-to-typescript-lite',
     'openapi-typescript',
+    '@types/json-schema',
   ],
   dts: true,
   unbundle: true,


### PR DESCRIPTION
Since index.js includes unnecessary CLI codes, etc., it also outputs TS packages in projects such as NitroJS and Nuxt. However, Apiful only uses these on the CLI side.

old:

<img width="1474" height="878" alt="CleanShot 2025-08-13 at 11 36 45@2x" src="https://github.com/user-attachments/assets/6233d885-6d4d-4e56-ad10-70fed42abe51" />


new:

<img width="1358" height="584" alt="CleanShot 2025-08-13 at 11 37 37@2x" src="https://github.com/user-attachments/assets/061f64c7-1cba-43dd-806f-e0c51c7e1a83" />
